### PR TITLE
Fix Front page broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@ home: true
 				<dt>Mobile</dt>
 				<dd>iOS, Android</dd>
 			</dl>
-			<a class="push-down" href="{{site.baseurl}}documentation/cross-platform/">Learn more</a>
+			<a class="push-down" href="{{site.baseurl}}documentation/tutorials/cross-platform/index.html>Learn more</a>
 		</div>
 
 		<div class="clearfix show-large hide-medium"></div>


### PR DESCRIPTION
The front page link to the cross-platform documentation is broken. I've fixed it.
